### PR TITLE
Added support for serializable objects with RxPreferences

### DIFF
--- a/library/src/androidTest/java/com/cocosw/favor/ApplicationTest.java
+++ b/library/src/androidTest/java/com/cocosw/favor/ApplicationTest.java
@@ -259,6 +259,20 @@ public class ApplicationTest extends ApplicationTestCase<Application> {
         assertEquals("http://www.cocosw.com", img.url);
     }
 
+    public void testRxSerializableObject() {
+        remove("avatar");
+        assertNull(profile.avatar().get());
+        Image avatar = new Image();
+        avatar.url = "http://www.cocosw.com";
+        avatar.format = "png";
+        profile.avatar().set(avatar);
+
+        Image img = profile.avatar().get();
+        assertNotNull(img);
+        assertEquals("png", img.format);
+        assertEquals("http://www.cocosw.com", img.url);
+    }
+
 
     public void testNegativeNumber() {
         FavorAdapter adapter = new FavorAdapter.Builder(getContext()).build();

--- a/library/src/androidTest/java/com/cocosw/favor/Profile.java
+++ b/library/src/androidTest/java/com/cocosw/favor/Profile.java
@@ -74,6 +74,9 @@ public interface Profile {
     Preference<Long> distance();
 
     @Favor
+    Preference<Image> avatar();
+
+    @Favor
     Image image();
 
     @Favor


### PR DESCRIPTION
Serializable objects can now be persisted via RxPreferences. This addresses ticket #12 . Unit test case has been added to validate the changes.
